### PR TITLE
Fix typo

### DIFF
--- a/webui/index.html
+++ b/webui/index.html
@@ -479,7 +479,7 @@
 					<h4 class="alert-heading">Loading configuration failed</h4>
 					Could not load template configuration file <em>nzbget.conf</em>. The file contains descriptions of options
 					and is needed to display settings page. The file comes with NZBGet distribution archive and is usually
-					automaically installed into the right location. This seems not to be a case with your installation though.<br><br>
+					automatically installed into the right location. This seems not to be a case with your installation though.<br><br>
 
 					<span id="ConfigLoadServerTemplateErrorEmpty">Please put the template configuration file <em>nzbget.conf</em> into the
 					directory with web-interface files (<em><span id="ConfigLoadServerTemplateErrorWebDir"></span></em>).</span>


### PR DESCRIPTION
On the "Loading configuration failed" message. automatically was spelt incorrectly.
